### PR TITLE
Clarify glitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `ChaoticJob::Helpers` module provides 6 methods, 4 of which simply allow you
 
 ### Glitches
 
-A glitch is an error injected into the job execution flow via a TracePoint and is implemented as a custom error class from ChaoticJob. This represents a transient error for testing a job's resilience to unpredictable failures that can occur while running jobs - rather than permanent errors resulting from your job's business logic, as those rely on the preconditions of your job rather and are directly testable without ChaoticJob. The glitch failure will occur once and only once, with the expectation that this force a retry that executes the job without the glitch to ensure resiliency to unexpected errors at specific points in the execution of a job.
+A central concept in `ChaoticJob` is the _glitch_. A glitch is an error injected into the job execution flow via a [`TracePoint`](https://docs.ruby-lang.org/en/master/TracePoint.html). Glitches are transient errors, which means they occur once and only once, making them perfect for testing a job's resilience to unpredictable failures that can occur while running jobs, like network issues, upstream API outages, rate limits, or  infrastructure failure. By default, `ChaoticJob` raises a custom error defined by the gem (`ChaoticJob::RetryableError`), which the internals of the gem ensure that the job under test is configured to retry on; you can, however, raise specific errors as needed when setting up your [scenarios](#simulating-failures). By forcing a retry via the error handling mechanisms of Active Job, glitches are a simple but effective way to test that your job is resilient to any kind of transient error that the job is configured to retry on.
 
 ### Performing Jobs
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ end
 
 The `ChaoticJob::Helpers` module provides 6 methods, 4 of which simply allow you to perform a job with retries in the proper way while the other 2 allow you to simulate failures and glitches.
 
+### Glitches
+
+A glitch is an error injected into the job execution flow via a TracePoint and is implemented as a custom error class from ChaoticJob. This represents a transient error for testing a job's resilience to unpredictable failures that can occur while running jobs - rather than permanent errors resulting from your job's business logic, as those rely on the preconditions of your job rather and are directly testable without ChaoticJob. The glitch failure will occur once and only once, with the expectation that this force a retry that executes the job without the glitch to ensure resiliency to unexpected errors at specific points in the execution of a job.
+
 ### Performing Jobs
 
 When testing job resilience, you will necessarily be testing how a job behaves when it retries. Unfortunately, the helpers provided by `ActiveJob::TestHelper` are tailored to testing the job's behavior on the first attempt.
@@ -130,8 +134,6 @@ def perform
   step_3
 end
 ```
-
-This glitch is a transient error, which are the only kind of errors that matter when testing resilience, as permanent errors mean your job will simply end up in the dead set. So, the glitch failure will occur once and only once, this forces a retry but does not prevent the job from completing.
 
 If you want to simulate multiple glitches affecting a job run, you can use the plural `glitches` keyword argument instead and pass an array of tuples:
 


### PR DESCRIPTION
As glitches are a central concept and terminology used to describe the behavior of this gem, this moves the definition to a more prominent location in the readme, and attempts to add clarification from the perspective of a person not-yet-familiar with this gem

---

I _think_ this accurately reflects the behavior and intent of glitches. Based on my attempt to wrap my head around this from [your response to my query on Mastodon](https://ruby.social/@fractaledmind/113447854256091618)