### PR TITLE
Add a Tracer class

### DIFF
--- a/lib/chaotic_job.rb
+++ b/lib/chaotic_job.rb
@@ -3,6 +3,7 @@
 require_relative "chaotic_job/version"
 require_relative "chaotic_job/journal"
 require_relative "chaotic_job/performer"
+require_relative "chaotic_job/tracer"
 require_relative "chaotic_job/glitch"
 require_relative "chaotic_job/scenario"
 require_relative "chaotic_job/simulation"

--- a/lib/chaotic_job/tracer.rb
+++ b/lib/chaotic_job/tracer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Tracer.new { |tp| tp.path.start_with? "foo" }
+# Tracer.new.capture { code_execution_to_trace_callstack }
+
+module ChaoticJob
+  class Tracer
+    def initialize(&constraint)
+      @constraint = constraint
+      @callstack = Set.new
+    end
+
+    def capture(&block)
+      trace = TracePoint.new(:line, :call) do |tp|
+        next if tp.defined_class == self.class
+        next unless @constraint.call(tp)
+
+        case tp.event
+        when :line
+          key = line_key(tp)
+        when :call
+          key = call_key(tp)
+        end
+
+        @callstack << [key, tp.path, tp.lineno]
+      end
+
+      trace.enable(&block)
+      @callstack.to_a
+    end
+
+    private
+
+    def line_key(event)
+      "#{event.path}:#{event.lineno}"
+    end
+
+    def call_key(event)
+      if Module === event.self
+        "#{event.self}.#{event.method_id}"
+      else
+        "#{event.defined_class}##{event.method_id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Expose a `Tracer` class to allow users to capture a constrained callstack, which could then be passed to a `Simulation`. This permits users to run simulations against a broader callstack beyond just the executed lines within the job.