### PR TITLE
All a Glitch to be defined for a method call

### DIFF
--- a/lib/chaotic_job/glitch.rb
+++ b/lib/chaotic_job/glitch.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Glitch.new.before("job_crucible.rb:10") { do_anything }
+# Glitch.new.before("Model#method", String, name: "Joel") { do_anything }
 # Glitch.new.after("job_crucible.rb:11") { do_anything }
 # Glitch.new.inject! { execute code to glitch }
 
@@ -8,31 +9,50 @@ module ChaoticJob
   class Glitch
     def initialize
       @breakpoints = {}
-      @file_contents = {}
     end
 
-    def before(path_with_line, &block)
-      set_breakpoint(path_with_line, :before, &block)
+    def before(key, ...)
+      set_breakpoint(key, :before, ...)
+      self
     end
 
-    def after(path_with_line, &block)
-      set_breakpoint(path_with_line, :after, &block)
+    def after(key, ...)
+      set_breakpoint(key, :after, ...)
+      self
     end
 
     def inject!
       prev_key = nil
-      trace = TracePoint.new(:line) do |tp|
-        key = "#{tp.path}:#{tp.lineno}"
-        # content = @file_contents[tp.path]
-        # line = content[tp.lineno - 1]
-        # next unless line.match? key
+      prev_params = nil
+      trace = TracePoint.new(:line, :call) do |tp|
+        key, params = nil
+
+        case tp.event
+        when :line
+          key = "#{tp.path}:#{tp.lineno}"
+        when :call
+          key = if Module === tp.self
+            "#{tp.self}.#{tp.method_id}"
+          else
+            "#{tp.defined_class}##{tp.method_id}"
+          end
+          params = tp.parameters.map do |type, name|
+            value = begin
+              tp.binding.local_variable_get(name)
+            rescue NameError
+              nil
+            end
+            [type, name, value]
+          end
+        end
 
         begin
-          execute_block(@breakpoints[prev_key][:after]) if prev_key && @breakpoints.key?(prev_key)
+          execute_block(@breakpoints[prev_key][:after]) if @breakpoints.key?(prev_key) && matches?(@breakpoints[prev_key][:after], prev_params)
 
-          execute_block(@breakpoints[key][:before]) if @breakpoints.key?(key)
+          execute_block(@breakpoints[key][:before]) if @breakpoints.key?(key) && matches?(@breakpoints[key][:before], params)
         ensure
           prev_key = key
+          prev_params = params
         end
       end
 
@@ -40,7 +60,43 @@ module ChaoticJob
       yield if block_given?
     ensure
       trace.disable
-      execute_block(@breakpoints[prev_key][:after]) if prev_key && @breakpoints.key?(prev_key)
+      execute_block(@breakpoints[prev_key][:after]) if @breakpoints.key?(prev_key) && matches?(@breakpoints[prev_key][:after], prev_params)
+    end
+
+    def matches?(defn, params)
+      return true if defn.nil?
+      return true if params.nil?
+      return true if defn[:args].empty?
+
+      args = []
+      kwargs = {}
+
+      params.each do |kind, name, value|
+        case kind
+        when :req
+          args << value
+        when :opt
+          args << value if value
+        when :rest
+          args.concat(value) if value
+        when :keyreq
+          kwargs[name] = value
+        when :key
+          kwargs[name] = value
+        when :keyrest
+          kwargs.merge!(value) if value
+        end
+      end
+
+      defn[:args].each_with_index do |type, index|
+        return false unless type === args[index]
+      end
+
+      defn[:kwargs].each do |key, type|
+        return false unless type === kwargs[key]
+      end
+
+      true
     end
 
     def all_executed?
@@ -57,11 +113,9 @@ module ChaoticJob
 
     private
 
-    def set_breakpoint(path_with_line, position, &block)
-      @breakpoints[path_with_line] ||= {}
-      # contents = File.read(file_path).split("\n") unless @file_contents.key?(path_with_line)
-      # @file_contents << contents
-      @breakpoints[path_with_line][position] = {block: block, executed: false}
+    def set_breakpoint(key, position, *args, **kwargs, &block)
+      @breakpoints[key] ||= {}
+      @breakpoints[key][position] = {args: args, kwargs: kwargs, block: block, executed: false}
     end
 
     def execute_block(handler)


### PR DESCRIPTION
possibly even constrained by arguments.

For example, given the following Ruby:
```ruby
class Foo
  def self.greet(name = "Dude", **kwargs) = puts "Wazzup, #{name}"
  def bye(name, salutation: "Bye") = puts "#{salutation}, #{name}"
end
```

This glitch:
```ruby
glitch = ChaoticJob::Glitch.new.after("Foo.greet", "Joel", greeting: String) { p 'GLITCHED!!!' }
glitch.inject! { Foo.greet("Joel", greeting: "Wazzup") }
```
would output:
```
Wazzup, Joel
"GLITCHED!!!"
```

While switching that same glitch to `before`
```ruby
glitch = ChaoticJob::Glitch.new.before("Foo.greet", "Joel", greeting: String) { p 'GLITCHED!!!' }
glitch.inject! { Foo.greet("Joel", greeting: "Wazzup") }
```
would output:
```
"GLITCHED!!!"
Wazzup, Joel
```

You can also define a `Glitch` for all method calls:
```ruby
glitch = ChaoticJob::Glitch.new.before("Foo.greet") { p 'GLITCHED!!!' }
glitch.inject! { Foo.greet("Joel", greeting: "Wazzup") }
```

And you can define a `Glitch` for instance methods as well:
```ruby
glitch = ChaoticJob::Glitch.new.before("Foo#bye") { p 'GLITCHED!!!' }
glitch.inject! { Foo.new.bye("Joel") }
```