### PR TITLE
Disconnect ActiveRecord connections after defining Simulation scenarios

### DIFF
--- a/lib/chaotic_job/simulation.rb
+++ b/lib/chaotic_job/simulation.rb
@@ -38,6 +38,10 @@ module ChaoticJob
           assert scenario.glitched?, "Scenario did not execute glitch: #{scenario.glitch}"
         end
       end
+
+      # Since the callstack capture likely touches the database and this code runs during test class definition,
+      # we need to disconnect the database connection before possible parallel test forking
+      ActiveRecord::Base.connection_pool.disconnect! if ActiveRecord::Base.connected?
     end
 
     private


### PR DESCRIPTION
if connected.