### PR TITLE
Refactor tracer

### DIFF
--- a/lib/chaotic_job/simulation.rb
+++ b/lib/chaotic_job/simulation.rb
@@ -94,7 +94,7 @@ module ChaoticJob
     end
 
     def capture_callstack
-      tracer = Tracer.new { |tp| @tracing.include?(tp.defined_class) }
+      tracer = Tracer.new(tracing: @tracing)
       callstack = tracer.capture do
         @template.dup.enqueue
         # run the template job as well as any other jobs it may enqueue

--- a/lib/chaotic_job/tracer.rb
+++ b/lib/chaotic_job/tracer.rb
@@ -7,7 +7,7 @@ module ChaoticJob
   class Tracer
     def initialize(tracing: nil, stack: Stack.new, effect: nil, returns: nil, &block)
       @trace = nil
-      @constraint = block_given? ? block : Array(tracing)
+      @constraint = block || Array(tracing)
       @stack = stack
       @effect = effect
       @returns = returns || @stack
@@ -23,13 +23,13 @@ module ChaoticJob
         next unless (Array === constraint) ? constraint.include?(tp.defined_class) : constraint.call(tp)
 
         key = case tp.event
-              when :line then line_key(tp)
-              when :call, :return then call_key(tp)
-              end
+        when :line then line_key(tp)
+        when :call, :return then call_key(tp)
+        end
         event = [tp.defined_class, tp.event, key]
 
         @stack << event
-        @effect.call if @effect
+        @effect&.call
         # :nocov:
       end
 

--- a/lib/chaotic_job/tracer.rb
+++ b/lib/chaotic_job/tracer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Tracer.new(tracing: Job)
+# Tracer.new { |tp| tp.path.start_with? "foo" }
 # tracer.capture { job.perform }
 
 module ChaoticJob

--- a/lib/chaotic_job/tracer.rb
+++ b/lib/chaotic_job/tracer.rb
@@ -1,34 +1,45 @@
 # frozen_string_literal: true
 
-# Tracer.new { |tp| tp.path.start_with? "foo" }
-# Tracer.new.capture { code_execution_to_trace_callstack }
+# Tracer.new(tracing: Job)
+# tracer.capture { job.perform }
 
 module ChaoticJob
   class Tracer
-    def initialize(&constraint)
-      @constraint = constraint
-      @callstack = Stack.new
+    def initialize(tracing: nil, stack: Stack.new, effect: nil, returns: nil, &block)
+      @trace = nil
+      @constraint = block_given? ? block : Array(tracing)
+      @stack = stack
+      @effect = effect
+      @returns = returns || @stack
     end
 
     def capture(&block)
-      trace = TracePoint.new(:line, :call, :return) do |tp|
+      constraint = @constraint
+      this = self.class
+
+      @trace = TracePoint.new(:line, :call, :return) do |tp|
         # :nocov: SimpleCov cannot track code executed _within_ a TracePoint
-        next if tp.defined_class == self.class
-        next unless @constraint.call(tp)
+        next if tp.defined_class == this
+        next unless (Array === constraint) ? constraint.include?(tp.defined_class) : constraint.call(tp)
 
-        case tp.event
-        when :line
-          key = line_key(tp)
-        when :call, :return
-          key = call_key(tp)
-        end
+        key = case tp.event
+              when :line then line_key(tp)
+              when :call, :return then call_key(tp)
+              end
+        event = [tp.defined_class, tp.event, key]
 
-        @callstack << [tp.event, key]
+        @stack << event
+        @effect.call if @effect
         # :nocov:
       end
 
-      trace.enable(&block)
-      @callstack
+      @trace.enable(&block)
+
+      @returns
+    end
+
+    def disable
+      @trace.disable
     end
 
     private

--- a/spec/chaotic_job/simulation_spec.rb
+++ b/spec/chaotic_job/simulation_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe ChaoticJob::Simulation do
       simulation = described_class.new(TestJob.new)
 
       stack = simulation.callstack.to_a
-      expect(stack[0]).to eq([:call, "TestJob#perform"])
-      expect(stack[1][0]).to eq(:line)
-      expect(stack[1][1]).to match(%r{chaotic_job/spec/spec_helper.rb:23})
-      expect(stack[2][0]).to eq(:line)
-      expect(stack[2][1]).to match(%r{chaotic_job/spec/spec_helper.rb:25})
-      expect(stack[3]).to eq([:return, "TestJob#perform"])
+      expect(stack[0]).to eq([TestJob, :call, "TestJob#perform"])
+      expect(stack[1][0]).to eq(TestJob)
+      expect(stack[1][1]).to eq(:line)
+      expect(stack[1][2]).to match(%r{chaotic_job/spec/spec_helper.rb:23})
+      expect(stack[2][0]).to eq(TestJob)
+      expect(stack[2][1]).to eq(:line)
+      expect(stack[2][2]).to match(%r{chaotic_job/spec/spec_helper.rb:25})
+      expect(stack[3]).to eq([TestJob, :return, "TestJob#perform"])
 
       expect(simulation.tracing).to eq([TestJob])
     end
@@ -38,12 +40,14 @@ RSpec.describe ChaoticJob::Simulation do
       simulation = described_class.new(TestJob.new, tracing: tracing)
 
       stack = simulation.callstack.to_a
-      expect(stack[0]).to eq([:call, "TestJob#perform"])
-      expect(stack[1][0]).to eq(:line)
-      expect(stack[1][1]).to match(%r{chaotic_job/spec/spec_helper.rb:23})
-      expect(stack[2][0]).to eq(:line)
-      expect(stack[2][1]).to match(%r{chaotic_job/spec/spec_helper.rb:25})
-      expect(stack[3]).to eq([:return, "TestJob#perform"])
+      expect(stack[0]).to eq([TestJob, :call, "TestJob#perform"])
+      expect(stack[1][0]).to eq(TestJob)
+      expect(stack[1][1]).to eq(:line)
+      expect(stack[1][2]).to match(%r{chaotic_job/spec/spec_helper.rb:23})
+      expect(stack[2][0]).to eq(TestJob)
+      expect(stack[2][1]).to eq(:line)
+      expect(stack[2][2]).to match(%r{chaotic_job/spec/spec_helper.rb:25})
+      expect(stack[3]).to eq([TestJob, :return, "TestJob#perform"])
 
       expect(simulation.tracing).to eq(tracing)
     end

--- a/test/chaotic_job/simulation_test.rb
+++ b/test/chaotic_job/simulation_test.rb
@@ -7,12 +7,14 @@ class ChaoticJob::SimulationTest < ActiveJob::TestCase
     simulation = ChaoticJob::Simulation.new(TestJob.new)
 
     stack = simulation.callstack.to_a
-    assert_equal stack[0], [:call, "TestJob#perform"]
-    assert_equal stack[1][0], :line
-    assert_match %r{chaotic_job/test/test_helper.rb:30}, stack[1][1]
-    assert_equal stack[2][0], :line
-    assert_match %r{chaotic_job/test/test_helper.rb:32}, stack[2][1]
-    assert_equal stack[3], [:return, "TestJob#perform"]
+    assert_equal [TestJob, :call, "TestJob#perform"], stack[0]
+    assert_equal TestJob, stack[1][0]
+    assert_equal :line, stack[1][1]
+    assert_match %r{chaotic_job/test/test_helper.rb:30}, stack[1][2]
+    assert_equal TestJob, stack[2][0]
+    assert_equal :line, stack[2][1]
+    assert_match %r{chaotic_job/test/test_helper.rb:32}, stack[2][2]
+    assert_equal [TestJob, :return, "TestJob#perform"], stack[3]
 
     assert_equal simulation.tracing, [TestJob]
   end
@@ -37,12 +39,14 @@ class ChaoticJob::SimulationTest < ActiveJob::TestCase
     simulation = ChaoticJob::Simulation.new(TestJob.new, tracing: tracing)
 
     stack = simulation.callstack.to_a
-    assert_equal stack[0], [:call, "TestJob#perform"]
-    assert_equal stack[1][0], :line
-    assert_match %r{chaotic_job/test/test_helper.rb:30}, stack[1][1]
-    assert_equal stack[2][0], :line
-    assert_match %r{chaotic_job/test/test_helper.rb:32}, stack[2][1]
-    assert_equal stack[3], [:return, "TestJob#perform"]
+    assert_equal [TestJob, :call, "TestJob#perform"], stack[0]
+    assert_equal TestJob, stack[1][0]
+    assert_equal :line, stack[1][1]
+    assert_match %r{chaotic_job/test/test_helper.rb:30}, stack[1][2]
+    assert_equal TestJob, stack[2][0]
+    assert_equal :line, stack[2][1]
+    assert_match %r{chaotic_job/test/test_helper.rb:32}, stack[2][2]
+    assert_equal [TestJob, :return, "TestJob#perform"], stack[3]
 
     assert_equal simulation.tracing, tracing
   end

--- a/test/chaotic_job/tracer_test.rb
+++ b/test/chaotic_job/tracer_test.rb
@@ -26,7 +26,7 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
     end
 
     assert_equal 3, result.size
-    assert_equal 3, result.count { |event, _| event == :line }
+    assert_equal 3, result.count { |_, event, _| event == :line }
   end
 
   test "capture traces call and return events" do
@@ -39,9 +39,9 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
     result = tracer.capture { test_method }
 
     assert_equal 4, result.size
-    assert_equal 1, result.count { |event, _| event == :call }
-    assert_equal 1, result.count { |event, _| event == :return }
-    assert_equal 2, result.count { |event, _| event == :line }
+    assert_equal 1, result.count { |_, event, _| event == :call }
+    assert_equal 1, result.count { |_, event, _| event == :return }
+    assert_equal 2, result.count { |_, event, _| event == :line }
   end
 
   test "constraint filters events" do
@@ -54,9 +54,9 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
     end
 
     assert_equal 2, result.size
-    assert_equal 0, result.count { |event, _| event == :call }
-    assert_equal 0, result.count { |event, _| event == :return }
-    assert_equal 2, result.count { |event, _| event == :line }
+    assert_equal 0, result.count { |_, event, _| event == :call }
+    assert_equal 0, result.count { |_, event, _| event == :return }
+    assert_equal 2, result.count { |_, event, _| event == :line }
   end
 
   test "line key format and stuff" do
@@ -65,10 +65,10 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
     result = tracer.capture { 42 }
 
     assert_equal 1, result.size
-    assert_equal 0, result.count { |event, _| event == :call }
-    assert_equal 0, result.count { |event, _| event == :return }
-    assert_equal 1, result.count { |event, _| event == :line }
-    assert result.all? { |_, key| key.include?(__FILE__) && key.include?(":") }
+    assert_equal 0, result.count { |_, event, _| event == :call }
+    assert_equal 0, result.count { |_, event, _| event == :return }
+    assert_equal 1, result.count { |_, event, _| event == :line }
+    assert result.all? { |_, _, key| key.include?(__FILE__) && key.include?(":") }
   end
 
   test "call key format for instance methods" do
@@ -81,10 +81,10 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
     result = tracer.capture { test_instance_method }
 
     assert_equal 4, result.size
-    assert_equal 1, result.count { |event, _| event == :call }
-    assert_equal 1, result.count { |event, _| event == :return }
-    assert_equal 2, result.count { |event, _| event == :line }
-    assert_equal 1, result.count { |event, key| event == :call && key.include?("#test_instance_method") }
+    assert_equal 1, result.count { |_, event, _| event == :call }
+    assert_equal 1, result.count { |_, event, _| event == :return }
+    assert_equal 2, result.count { |_, event, _| event == :line }
+    assert_equal 1, result.count { |_, event, key| event == :call && key.include?("#test_instance_method") }
   end
 
   test "excludes tracer class from tracing" do
@@ -92,7 +92,7 @@ class ChaoticJob::TracerTest < ActiveJob::TestCase
 
     result = tracer.capture { 1 + 1 }
 
-    assert_equal 0, result.count { |_, key| key.to_s.include?("ChaoticJob::Tracer") }
+    assert_equal 0, result.count { |_, _, key| key.to_s.include?("ChaoticJob::Tracer") }
   end
 
   test "empty capture when constraint rejects all" do


### PR DESCRIPTION
Make the Tracer class more flexible so users can pass `tracing` array, custom `stack`, an `effect` proc, and a `returns`
value