### PR TITLE
Add a Race class to orchestrate concurrent job executions

### DIFF
--- a/lib/chaotic_job.rb
+++ b/lib/chaotic_job.rb
@@ -8,6 +8,7 @@ require_relative "chaotic_job/glitch"
 require_relative "chaotic_job/scenario"
 require_relative "chaotic_job/simulation"
 require_relative "chaotic_job/switch"
+require_relative "chaotic_job/race"
 require "set"
 
 module ChaoticJob

--- a/lib/chaotic_job/race.rb
+++ b/lib/chaotic_job/race.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ChaoticJob
+  class Race
+    EVENT = :event_occurred
+
+    attr_reader :executions
+
+    def initialize(jobs, pattern)
+      @jobs = jobs
+      @pattern = pattern
+      @executions = []
+      @traces = []
+      @fibers = {}
+    end
+
+    def run!
+      @jobs.each { |job| @fibers[job.class] = traced_fiber_for(job) }
+      fibers = @fibers
+
+      @pattern.each do |klass, _type, _key|
+        fiber = fibers[klass]
+
+        break unless fiber.alive?
+
+        result = fiber.resume
+
+        break unless result == EVENT
+      end
+
+      # Clean up to prevent FiberError when accessing job methods later
+      cleanup_traces
+      cleanup_fibers
+    end
+
+    def success?
+      @executions == @pattern
+    end
+
+    private
+
+    def traced_fiber_for(job)
+      Fiber.new do
+        tracer = Tracer.new(
+          tracing: job.class,
+          stack: @executions,
+          effect: -> { Fiber.yield EVENT }
+        )
+        @traces << tracer
+        tracer.capture { job.perform }
+      end
+    end
+
+    def cleanup_traces
+      @traces.each(&:disable)
+      @traces.clear
+    end
+
+    def cleanup_fibers
+      @fibers.values.each(&:kill)
+      @fibers.clear
+    end
+  end
+end

--- a/test/chaotic_job/race_test.rb
+++ b/test/chaotic_job/race_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Job1 < ActiveJob::Base
+  def perform
+    ChaoticJob.log_to_journal! serialize
+    1 + 2
+  end
+end
+
+class Job2 < ActiveJob::Base
+  def perform
+    ChaoticJob.log_to_journal! serialize
+    step
+  end
+
+  def step
+    1 + 2
+  end
+end
+
+class ChaoticJob::RaceTest < ActiveJob::TestCase
+  test "can run a race with an interleaved callstacks pattern" do
+    # prep phase
+    job1 = Job1.new
+    job2 = Job2.new
+
+    job1_callstack = ChaoticJob::Tracer.new(tracing: Job1).capture do
+      job1.enqueue
+      ChaoticJob::Performer.perform_all
+    end
+    job2_callstack = ChaoticJob::Tracer.new(tracing: Job2).capture do
+      job2.enqueue
+      ChaoticJob::Performer.perform_all
+    end
+
+    pattern = job1_callstack.to_a.zip(job2_callstack.to_a).flatten(1)
+
+    race = ChaoticJob::Race.new([job1, job2], pattern)
+    race.run!
+
+    assert race.success?
+    assert_equal pattern, race.executions
+  end
+end


### PR DESCRIPTION
A big step in the direction of fulfilling #24

A `Race` is an orchestrated executor that takes a collection of job instances and a linear sequence pattern of exhaustive execution events. It performs those jobs concurrently, ensuring that the pattern of events is executed in order. This is a simulation of a race condition, which is typically a bug that occurs when two linear sequence of execution events get interleaved in such a way as to produce an unexpected effect. By having an executor that can force multiple concurrent execution streams to follow a fixed pattern, we can test particular race condition scenarios deterministically.