### PR TITLE
Fix Glitch#derive_key invoking overridable methods on traced objects

### DIFF
--- a/lib/chaotic_job/glitch.rb
+++ b/lib/chaotic_job/glitch.rb
@@ -130,7 +130,14 @@ module ChaoticJob
         "#{trace.path}:#{trace.lineno}"
       when :call, :return
         if Module === trace.self
-          "#{trace.self}.#{trace.method_id}"
+          # Module#name via bind_call, never interpolation: interpolating
+          # trace.self invokes overridable to_s/inspect machinery on EVERY
+          # traced call — which explodes when, e.g., an ActiveRecord model is
+          # first autoloaded inside an active glitch (AR's inspect resolves
+          # table_name through a class still running its inherited hooks).
+          # Anonymous modules derive a nil-name key, which simply never
+          # matches — same outcome as their unmatchable #<Class:0x...> form.
+          "#{Module.instance_method(:name).bind_call(trace.self)}.#{trace.method_id}"
         else
           "#{trace.defined_class}##{trace.method_id}"
         end

--- a/test/chaotic_job/glitch_test.rb
+++ b/test/chaotic_job/glitch_test.rb
@@ -915,6 +915,45 @@ class ChaoticJob::GlitchTest < ActiveJob::TestCase
     assert_equal block, glitch.instance_variable_get(:@block)
   end
 
+  test "deriving keys never invokes overridable methods on traced objects" do
+    # Interpolating trace.self calls to_s/inspect on every traced class-level
+    # call. Classes can override those with methods that are unsafe mid-trace
+    # (ActiveRecord's inspect resolves table_name, which explodes while a
+    # model class is still running its inherited hooks during autoload).
+    class LoudClass
+      @calls = 0
+
+      def self.to_s
+        raise "to_s invoked during trace"
+      end
+
+      def self.inspect
+        raise "inspect invoked during trace"
+      end
+
+      def self.step
+        @calls += 1
+        ChaoticJob.log_to_journal!(:"step_#{@calls}")
+      end
+    end
+
+    # an UNRELATED glitch is active while the loud class's singleton method
+    # is traced — deriving its key must not touch to_s/inspect
+    bystander = ChaoticJob::Glitch.before_call("DoesNotExist#does_not_exist") {}
+    bystander.inject! { LoudClass.step }
+
+    assert_equal [:step_1], ChaoticJob.journal_entries
+
+    # and the class is still matchable by its REAL name despite the overrides
+    glitch = ChaoticJob::Glitch.before_call("#{self.class.name}::LoudClass.step") do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+    glitch.inject! { LoudClass.step }
+
+    assert_equal [:step_1, :glitch, :step_2], ChaoticJob.journal_entries
+    assert glitch.executed?
+  end
+
   test "set_action leaves block when one already set unless forced" do
     glitch = ChaoticJob::Glitch.before_call("DoesNotExist#does_not_exist") do
       ChaosJob.log_to_journal!(:glitch)


### PR DESCRIPTION
## Summary

`derive_key` interpolates `trace.self` for every traced class-level call, which invokes user-overridable `to_s`/`inspect` machinery. Some standard overrides are unsafe mid-trace: ActiveRecord's `Class#inspect` resolves `table_name`, which raises `NoMethodError (undefined method 'table_name' for nil)` while a model class is still executing AR's `inherited` hooks — i.e. whenever an AR model is **first autoloaded inside an active glitch**.

Found in production use: a Rails app's chaos suite (lazy autoloading, the test-env default) had a latent load-order flake — any glitched example that ran before anything else had loaded a particular model failed with an unrelated autoload explosion. CI masked it via eager loading.

```
NoMethodError: undefined method 'table_name' for nil
  activerecord/lib/active_record/model_schema.rb:639:in 'compute_table_name'
  ...
  activerecord/lib/active_record/core.rb:383:in 'inspect'
  chaotic_job/glitch.rb:133:in 'derive_key'   <-- the interpolation
  ...
  activerecord/lib/active_record/enum.rb:291:in 'inherited'
```

## Fix

`Module.instance_method(:name).bind_call(trace.self)` — never touches user-space machinery, and also resists `name`/`to_s` overrides on the traced class itself. Anonymous modules derive a nil-name key that never matches — the same outcome as their previous unmatchable `#<Class:0x...>` form.

## Test

The regression test defines a class whose `to_s`/`inspect` raise, proves an unrelated active glitch doesn't explode when its methods are traced, and proves the class is still matchable by its real name. Without the fix it errors exactly as production did.

## Test plan
- [x] `bundle exec rake test` — 125 runs, 308 assertions, 0 failures (was 124 runs)
- [x] regression test errors without the fix, passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)