### PR TITLE
Glitch: target the nth matching occurrence (nth:)

### DIFF
--- a/lib/chaotic_job/glitch.rb
+++ b/lib/chaotic_job/glitch.rb
@@ -3,31 +3,37 @@
 # Glitch.before_line("job_crucible.rb:10") { do_anything }
 # Glitch.before_call("Model#method", String, name: "Joel") { do_anything }
 # Glitch.before_return("Model#method", String, name: "Joel") { do_anything }
+# Glitch.before_call("Model#method", nth: 2) { do_anything }
 # Glitch.inject! { execute code to glitch }
 
 module ChaoticJob
   class Glitch
-    def self.before_line(key, &block)
-      new(key, :line, &block)
+    def self.before_line(key, nth: 1, &block)
+      new(key, :line, nth: nth, &block)
     end
 
     def self.before_call(key, ...)
       new(key, :call, ...)
     end
 
-    def self.before_return(key, return_type = nil, &block)
-      new(key, :return, retval: return_type, &block)
+    def self.before_return(key, return_type = nil, nth: 1, &block)
+      new(key, :return, retval: return_type, nth: nth, &block)
     end
 
     attr_reader :key, :event
 
-    def initialize(key, event, *args, retval: nil, **kwargs, &block)
+    # `nth:` targets the nth MATCHING occurrence (1-indexed) — "fail the
+    # second insert" without glitching the first. It is reserved here, so a
+    # keyword-argument matcher literally named `nth` cannot be expressed.
+    def initialize(key, event, *args, retval: nil, nth: 1, **kwargs, &block)
       @event = event
       @key = key
       @args = args
       @retval = retval
+      @nth = nth
       @kwargs = kwargs
       @block = block
+      @matched = 0
       @executed = false
     end
 
@@ -43,6 +49,9 @@ module ChaoticJob
 
         matchers = derive_matchers(tp)
         next unless matches?(matchers)
+
+        @matched += 1
+        next unless @matched == @nth
 
         execute_block
         # :nocov:
@@ -69,6 +78,7 @@ module ChaoticJob
       buffer << "  args: #{@args}\n" if @args.any?
       buffer << "  kwargs: #{@kwargs}\n" if @kwargs.any?
       buffer << "  retval: #{@retval}\n" if @retval
+      buffer << "  nth: #{@nth}\n" if @nth != 1
       buffer << ")"
 
       buffer

--- a/test/chaotic_job/glitch_test.rb
+++ b/test/chaotic_job/glitch_test.rb
@@ -915,6 +915,74 @@ class ChaoticJob::GlitchTest < ActiveJob::TestCase
     assert_equal block, glitch.instance_variable_get(:@block)
   end
 
+  test "glitch targets the nth matching call" do
+    class Job13 < ActiveJob::Base
+      def perform
+        3.times { |i| step(i + 1) }
+      end
+
+      def step(n)
+        ChaoticJob.log_to_journal!(:"step_#{n}")
+      end
+    end
+
+    glitch = ChaoticJob::Glitch.before_call("#{Job13.name}#step", nth: 2) do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+    glitch.inject! { Job13.perform_now }
+
+    assert_equal [:step_1, :glitch, :step_2, :step_3], ChaoticJob.journal_entries
+    assert glitch.executed?
+  end
+
+  test "glitch never executes when fewer matching calls occur than nth" do
+    class Job14 < ActiveJob::Base
+      def perform
+        step
+      end
+
+      def step
+        ChaoticJob.log_to_journal!(:step)
+      end
+    end
+
+    glitch = ChaoticJob::Glitch.before_call("#{Job14.name}#step", nth: 2) do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+    glitch.inject! { Job14.perform_now }
+
+    assert_equal [:step], ChaoticJob.journal_entries
+    refute glitch.executed?
+  end
+
+  test "glitch targets the nth matching line execution" do
+    class Job15 < ActiveJob::Base
+      @calls = 0
+
+      class << self
+        attr_accessor :calls
+      end
+
+      def perform
+        2.times { step }
+      end
+
+      def step
+        self.class.calls += 1
+        ChaoticJob.log_to_journal!(:"step_#{self.class.calls}")
+      end
+    end
+
+    line = Job15.instance_method(:step).source_location
+    glitch = ChaoticJob::Glitch.before_line("#{line[0]}:#{line[1] + 1}", nth: 2) do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+    glitch.inject! { Job15.perform_now }
+
+    assert_equal [:step_1, :glitch, :step_2], ChaoticJob.journal_entries
+    assert glitch.executed?
+  end
+
   test "set_action leaves block when one already set unless forced" do
     glitch = ChaoticJob::Glitch.before_call("DoesNotExist#does_not_exist") do
       ChaosJob.log_to_journal!(:glitch)


### PR DESCRIPTION
## Summary

Adds `nth:` to `Glitch.before_line` / `before_call` / `before_return` — the glitch fires on the **nth matching occurrence** instead of always the first:

```ruby
Glitch.before_call("Transfer#save!", nth: 2) { raise ActiveRecord::ConnectionNotEstablished }
```

Motivation from production use: testing "a multi-record batch whose SECOND insert dies" was inexpressible — the glitch always hit the first call, so the test had to drop to an adapter-level DB fault helper with a hand-rolled skip counter. `nth:` keeps that scenario in chaotic_job.

Design notes:
- Default `nth: 1` preserves existing behavior exactly.
- The count increments only on **matching** occurrences (key AND argument matchers), so `nth: 2` with `String, name: "Joel"` means "the second call that also matches those arguments."
- `executed?` stays false if fewer than `nth` matches occur — covered by a test.
- `nth` is reserved on the constructor, so a keyword-argument *matcher* literally named `nth` can't be expressed; noted in the signature comment.

## Test plan
- [x] nth call targeting (journal order proves first call untouched)
- [x] under-count → never executes, `executed?` false
- [x] nth line execution
- [x] full suite: 127 runs, 311 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)