### PR TITLE
Glitch: strict injection raises when the glitch never fires

### DIFF
--- a/lib/chaotic_job.rb
+++ b/lib/chaotic_job.rb
@@ -15,6 +15,10 @@ require "set"
 module ChaoticJob
   Error = Class.new(StandardError)
   RetryableError = Class.new(Error)
+  # A glitch with a typo'd key (or a key the block never reaches) is a
+  # silent no-op — the test passes while injecting nothing. Strict
+  # injection (Glitch#inject!(strict: true)) turns that into this failure.
+  Glitch::NeverExecutedError = Class.new(Error)
   Stack = Set
   ActiveSupportEvent = Struct.new(:name, :started, :finished, :unique_id, :payload)
   TracedEvent = Struct.new(:owner, :type, :key)

--- a/lib/chaotic_job/glitch.rb
+++ b/lib/chaotic_job/glitch.rb
@@ -4,6 +4,7 @@
 # Glitch.before_call("Model#method", String, name: "Joel") { do_anything }
 # Glitch.before_return("Model#method", String, name: "Joel") { do_anything }
 # Glitch.inject! { execute code to glitch }
+# Glitch.inject!(strict: true) { ... } # raises NeverExecutedError if the glitch never fired
 
 module ChaoticJob
   class Glitch
@@ -35,7 +36,7 @@ module ChaoticJob
       @block = block if @block.nil? || force
     end
 
-    def inject!(&block)
+    def inject!(strict: false, &block)
       trace = TracePoint.new(@event) do |tp|
         # :nocov: SimpleCov cannot track code executed _within_ a TracePoint
         key = derive_key(tp)
@@ -48,7 +49,13 @@ module ChaoticJob
         # :nocov:
       end
 
-      trace.enable(&block)
+      result = trace.enable(&block)
+
+      # Only on the success path: if the block itself raised, that error
+      # propagates untouched — strictness must never mask a real failure.
+      raise NeverExecutedError, "glitch never executed: #{self}" if strict && !executed?
+
+      result
     end
 
     def executed?

--- a/test/chaotic_job/glitch_test.rb
+++ b/test/chaotic_job/glitch_test.rb
@@ -915,6 +915,54 @@ class ChaoticJob::GlitchTest < ActiveJob::TestCase
     assert_equal block, glitch.instance_variable_get(:@block)
   end
 
+  test "strict injection raises when the glitch never executes" do
+    class Job16 < ActiveJob::Base
+      def perform
+        step
+      end
+
+      def step
+        ChaoticJob.log_to_journal!(:step)
+      end
+    end
+
+    # a typo'd key is otherwise a silent no-op
+    glitch = ChaoticJob::Glitch.before_call("#{Job16.name}#setp") do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+
+    error = assert_raises(ChaoticJob::Glitch::NeverExecutedError) do
+      glitch.inject!(strict: true) { Job16.perform_now }
+    end
+
+    assert_match(/setp/, error.message)
+    assert_equal [:step], ChaoticJob.journal_entries
+
+    # a glitch that fires passes strict injection
+    fired = ChaoticJob::Glitch.before_call("#{Job16.name}#step") do
+      ChaoticJob.log_to_journal!(:glitch)
+    end
+    fired.inject!(strict: true) { Job16.perform_now }
+
+    assert fired.executed?
+  end
+
+  test "strict injection never masks an error raised by the block itself" do
+    class Job17 < ActiveJob::Base
+      def perform
+        raise "the real failure"
+      end
+    end
+
+    glitch = ChaoticJob::Glitch.before_call("#{Job17.name}#nope") {}
+
+    error = assert_raises(RuntimeError) do
+      glitch.inject!(strict: true) { Job17.new.perform }
+    end
+
+    assert_equal "the real failure", error.message
+  end
+
   test "set_action leaves block when one already set unless forced" do
     glitch = ChaoticJob::Glitch.before_call("DoesNotExist#does_not_exist") do
       ChaosJob.log_to_journal!(:glitch)


### PR DESCRIPTION
## Summary

```ruby
glitch = Glitch.before_call("Transfer#sav!") { raise } # note the typo
glitch.inject!(strict: true) { job.perform_now }
# => ChaoticJob::Glitch::NeverExecutedError: glitch never executed: ChaoticJob::Glitch(...)
```

A glitch whose key is typo'd — or whose code path the block never reaches — is currently a silent no-op: the test passes while injecting nothing, certifying resilience it never exercised. `executed?` covers this, but asserting it is opt-in discipline; in a real chaos suite I audited, exactly one of seven glitch examples remembered to.

Design:
- `inject!(strict: true)`, default off — zero behavior change for existing callers.
- The check runs **only on the success path**: if the block itself raises (the usual case — most glitches inject errors the test then asserts on), that error propagates untouched. Strictness never masks a real failure. Covered by a test.
- `NeverExecutedError < ChaoticJob::Error`, defined alongside `Error`/`RetryableError` in `chaotic_job.rb` (glitch.rb loads before `Error` exists).
- The message includes `Glitch#to_s`, so the typo'd key is visible in the failure.

## Test plan
- [x] typo'd key + strict → raises, message names the key, work still ran
- [x] firing glitch + strict → passes
- [x] block's own error propagates unmasked under strict
- [x] full suite: 126 runs, 312 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)